### PR TITLE
__init__.py: fix for Python 3 compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,7 +35,7 @@ reload(plugin) # In case we're being reloaded.
 # reloaded when this plugin is reloaded.  Don't forget to import them as well!
 
 if world.testing:
-    import test
+    from . import test
 
 Class = plugin.Class
 configure = config.configure


### PR DESCRIPTION
This makes sure the tests are loaded on Python 3. See reticulatingspline/Weather#9
