### PR TITLE
Missing index variable in for loop

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -107,7 +107,7 @@ class UrbanDictionary(callbacks.Plugin):
             for i in definitions[0:args['numberOfDefinitions']]:  # iterate through each def.
                 # clean these up.
                 definition = self.cleanjson(''.join(i['definition'])) #.encode('utf-8')
-                example = self.cleanjson(''.join(['example']))
+                example = self.cleanjson(''.join(i['example']))
                 # now add
                 outputstring = "{0}".format(definition)  # default string.
                 if args['showExamples']:  # show examples?


### PR DESCRIPTION
Plugin output examples only showed "example" due to a missing index variable during assignment of the "example" variable.  The index variable was added, output tested successfully.